### PR TITLE
fixed: Exception in HostFunction: android.content.res.TypedArray cann…

### DIFF
--- a/android/src/main/java/com/material3/reactnative/ColorsModule.kt
+++ b/android/src/main/java/com/material3/reactnative/ColorsModule.kt
@@ -189,8 +189,10 @@ class ColorsModule(reactContext: ReactApplicationContext) : NativeColorsSpec(rea
 
   private fun getColorFromAttr(@AttrRes attr: Int): String {
     val typedArray = themedContext!!.theme.obtainStyledAttributes(intArrayOf(attr))
-    val color = typedArray.use {
-      it.getColor(0, 0)
+    val color = try {
+      typedArray.getColor(0, 0)
+    } finally {
+      typedArray.recycle()
     }
 
     val alpha = (color shr 24) and 0xFF


### PR DESCRIPTION
When I tried to run: yarn example android, I got this error: Exception in HostFunction: android.content.res.TypedArray cannot be cast to java.lang.AutoCloseable @ file: colors.ts 
![Screenshot_1736550844](https://github.com/user-attachments/assets/e269d937-26d7-4a19-91a0-2a2734dec66b)
